### PR TITLE
Update some outdated docs in phoenix project

### DIFF
--- a/phoenix/test/support/plugs/e2e_plug.ex
+++ b/phoenix/test/support/plugs/e2e_plug.ex
@@ -1,11 +1,9 @@
 defmodule E2E.E2EPlug do
   @moduledoc """
-  Exposes endpoints required for effective writing of E2E tests
+  Exposes endpoints which allow the frontend to remotely call factory functions
+  for test setup.
 
-  GET /api/sent_emails renders a JSON of sent emails
-  POST /api/factory can be used to create database records, similar to how it's done in unit tests
 
-  Is effectively a rudimentary interface to `:ex_machina`.
   """
   @behaviour Plug
 
@@ -27,7 +25,7 @@ defmodule E2E.E2EPlug do
   def call(%Conn{method: "POST", request_path: "/api/factory"} = conn, enabled: true) do
     with {:ok, schema} <- Map.fetch(conn.body_params, "schema"),
          {:ok, attrs} <- Map.fetch(conn.body_params, "attributes") do
-      db_schema = String.to_atom(schema)
+      db_schema = String.to_existing_atom(schema)
       db_attrs = atomize(attrs)
 
       rendered =
@@ -35,9 +33,9 @@ defmodule E2E.E2EPlug do
         |> create(db_attrs, Map.get(conn.body_params, "count"))
         |> Jason.encode!()
 
-      Conn.send_resp(conn, 200, rendered) |> Conn.halt()
+      conn |> Conn.send_resp(200, rendered) |> Conn.halt()
     else
-      _ -> Conn.send_resp(conn, 401, "schema or attributes missing") |> Conn.halt()
+      _ -> conn |> Conn.send_resp(401, "schema or attributes missing") |> Conn.halt()
     end
   end
 
@@ -52,8 +50,9 @@ defmodule E2E.E2EPlug do
   def create(schema, %{} = attrs, count), do: SandboxFactory.insert_list(count, schema, attrs)
 
   @spec atomize(any) :: any
-  defp atomize(%{} = attrs),
-    do: Enum.map(attrs, fn {k, v} -> {String.to_atom(k), atomize(v)} end) |> Enum.into(%{})
+  defp atomize(%{} = attrs) do
+    Enum.map(attrs, fn {k, v} -> {String.to_existing_atom(k), atomize(v)} end) |> Enum.into(%{})
+  end
 
   defp atomize(attrs) when is_list(attrs), do: Enum.map(attrs, &atomize/1)
   defp atomize(v), do: v

--- a/phoenix/test/support/plugs/sandbox_enforcer_plug.ex
+++ b/phoenix/test/support/plugs/sandbox_enforcer_plug.ex
@@ -1,12 +1,7 @@
 defmodule E2E.SandboxEnforcerPlug do
   @moduledoc """
-  Adds support for sandbox mode in the e2e environment.
-
-  In sandbox mode, the following is in effect
-
-  - the `GET /api/ping` endpoint is enabled, which is used by Jenkins to check if API is up
-  - the `POST /api/sandbox` and `DELETE /api/sandbox` endpoints are enabled, to checkout and checkin an Ecto sandbox connection
-  - all other endpoints return an error if a `sandbox` header with a valid sandbox id is not present
+  Ensures any request that doesn't have a sandbox id header while we are in e2e
+  mode, will error out with a 400.
   """
   @behaviour Plug
 


### PR DESCRIPTION
# What this PR does

It updates some outdated copy-pasta docs in 2 phoenix modules

## It also

- re-enables CI. It got accidentally removed due to renaming the master branch to main
- renames CI jobs, so they can be more easily differentiated